### PR TITLE
Removing this rule, it's too annoying

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -189,7 +189,7 @@ module.exports = {
 		'no-whitespace-before-property': 2,
 
 		// enforce consistent line breaks inside of braces
-		'object-curly-newline': [2, {'multiline': true}],
+		'object-curly-newline': 0,
 
 		// enforce consistent spacing inside braces
 		'object-curly-spacing': [2, 'never'],


### PR DESCRIPTION
I found that the style this rule tries to promote is too irksome and goes against what I understand to be common conventions for {} and objects. 