### PR TITLE
added import rule set to allow us to use the linter with import and r…

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
 	extends: [
 		'./rules/best-practices',
 		'./rules/ecma-script6',
+		'./rules/imports',
 		'./rules/node',
 		'./rules/possible-errors',
 		'./rules/strict-mode',

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -1,0 +1,98 @@
+'use strict';
+
+module.exports = {
+  'rules': {
+    // Static analysis:
+
+    // ensure imports point to files/modules that can be resolved
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
+    'import/no-unresolved': [2, { 'commonjs': true }],
+
+    // ensure named imports coupled with named exports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md#when-not-to-use-it
+    'import/named': 0,
+
+    // ensure default import coupled with default export
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md#when-not-to-use-it
+    'import/default': 0,
+
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md
+    'import/namespace': 0,
+
+    // Helpful warnings:
+
+    // disallow invalid exports, e.g. multiple defaults
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md
+    'import/export': 2,
+
+    // do not allow a default import name to match a named export
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md
+    // TODO: enable
+    'import/no-named-as-default': 0,
+
+    // warn on accessing default export property names that are also named exports
+    // TODO: enable?
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default-member.md
+    'import/no-named-as-default-member': 1,
+
+    // disallow use of jsdoc-marked-deprecated imports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-deprecated.md
+    'import/no-deprecated': 0,
+
+    // Forbid mutable exports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md
+    'import/no-mutable-exports': 2,
+
+    // Module systems:
+
+    // disallow require()
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-commonjs.md
+    'import/no-commonjs': 0,
+
+    // disallow AMD require/define
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-amd.md
+    'import/no-amd': 2,
+
+    // No Node.js builtin modules
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-nodejs-modules.md
+    'import/no-nodejs-modules': 0,
+
+    // Style guide:
+
+    // disallow non-import statements appearing before import statements
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/imports-first.md
+    'import/imports-first': [2, 'absolute-first'],
+
+    // disallow duplicate imports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
+    'import/no-duplicates': 2,
+
+    // disallow namespace imports
+    // TODO: enable?
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-namespace.md
+    'import/no-namespace': 0,
+
+    // Ensure consistent use of file extension within the import path
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
+    // TODO: enable
+    'import/extensions': [0, 'never'],
+
+    // Enforce a convention in module import order
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
+    // TODO: enable?
+    'import/order': [0, {
+      'groups': ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+      'newlines-between': 'never',
+    }],
+
+    // Require a newline after the last import/require in a group
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/newline-after-import.md
+    // TODO: enable
+    'import/newline-after-import': 2,
+
+    // Require modules with a single export to use a default export
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
+    // TODO: enable
+    'import/prefer-default-export': 1
+  }
+}


### PR DESCRIPTION
import rule set gives access to a set of rules that will help lint require and import statements. Of special interest is the 'import/no-unresolved' rule which will throw an error if you type an invalid filepath into your require statement in nodeland. 