### PR TITLE
Change max-lines to warn

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -94,7 +94,7 @@ module.exports = {
 		}],
 
 		// enforce a maximum file length
-		'max-lines': [2, 200],
+		'max-lines': [1, 200],
 
 		// enforce max nested callbacks
 		'max-nested-callbacks': [2, {'max': 5}],


### PR DESCRIPTION
While we should definitely strive to keep our files within a reasonable size, we have some patterns to hammer out around how we do this and sometimes work just has to get done.

Proposing we relax this to a warning, at least for now until we have established much better practices amongst the team of how to properly fix these issues when they arise.