### PR TITLE
Indent MemberExpression

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -51,7 +51,7 @@ module.exports = {
 		'id-length': [1, {'min': 2, 'max': 30, 'exceptions': ['_']}],
 
 		// enforce consistent indentation
-		'indent': [2, 'tab', {'SwitchCase': 1}],
+		'indent': [2, 'tab', {'SwitchCase': 1, 'MemberExpression': 1}],
 
 		// enforce consistent use of string quotation style with jsx attributes
 		'jsx-quotes': 0,


### PR DESCRIPTION
This patch adds enforcement indentation for multi-line property chains.
http://eslint.org/docs/rules/indent#memberexpression

Example of incorrect code:
```
foo
.bar
.baz()
```

Example of correct code:
```
foo
  .bar
  .baz()
```

We have had a few back and forths on PRs regarding this and I think it's time we settle it for good here and now and let the linter be responsible.

@kingchad speak now or forever hold your peace 😛 