### PR TITLE
tabs -> spaces

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -51,7 +51,7 @@ module.exports = {
 		'id-length': [1, {'min': 2, 'max': 30, 'exceptions': ['_']}],
 
 		// enforce consistent indentation
-		'indent': [2, 'tab', {'SwitchCase': 1, 'MemberExpression': 1}],
+		'indent': [2, 2, {'SwitchCase': 1, 'MemberExpression': 1}],
 
 		// enforce consistent use of string quotation style with jsx attributes
 		'jsx-quotes': 0,


### PR DESCRIPTION
Now that the official rule is to use 2-space indentation for all projects, and repository updates have been propagated, we can now enforce this change in eslint.