### PR TITLE
feat: prefer shorthand assignment

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -203,8 +203,8 @@ module.exports = {
     // enforce consistent variable declaration style
     'one-var': [2, 'never'],
 
-    // prevent use of operator shorthand
-    'operator-assignment': [2, 'never'],
+    // disable enforcement of operator shorthand
+    'operator-assignment': 0,
 
     // enforce consistent linebreak style for operators
     'operator-linebreak': [2, 'after'],


### PR DESCRIPTION
- Change to prefer shorthand operator assignment, i.e. `a += b` over `a = a + b`

http://eslint.org/docs/rules/operator-assignment