### PR TITLE
feat(no-mixed-operators): disable rule

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -142,7 +142,7 @@ module.exports = {
     'no-lonely-if': 2,
 
     // prevents the use of mixed logical operators with out parentheses
-    'no-mixed-operators': [2, {'allowSamePrecedence': true}],
+    'no-mixed-operators': 0,
 
     // prevents mixed indentation style
     'no-mixed-spaces-and-tabs': [2, 'smart-tabs'],


### PR DESCRIPTION
- Disable `no-mixed-operators` rule as this adds nothing and forces unnecessary breakup of valid calculations

http://eslint.org/docs/rules/no-mixed-operators