### PR TITLE
feat(one-var): allow multiple declarations

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -198,10 +198,10 @@ module.exports = {
     'object-property-newline': [2, {'allowMultiplePropertiesPerLine': true}],
 
     // enforce consistent line use around variable declarations
-    'one-var-declaration-per-line': 2,
+    'one-var-declaration-per-line': [2, "initializations"],
 
     // enforce consistent variable declaration style
-    'one-var': [2, 'never'],
+    'one-var': 0,
 
     // disable enforcement of operator shorthand
     'operator-assignment': 0,


### PR DESCRIPTION
- Change to allow multiple declarations in one line
- Relax `one-var-declaration-per-line` to allow multiple declarations in one line but force line breaks on initialization of variables

http://eslint.org/docs/rules/one-var
http://eslint.org/docs/rules/one-var-declaration-per-line