### PR TITLE
Relax declaration & return newline rules

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -119,10 +119,10 @@ module.exports = {
     'new-parens': 2,
 
     // require empty an line after variable declaration
-    'newline-after-var': [2, 'always'],
+    'newline-after-var': 0,
 
     // enforce consistent spacing before return statements
-    'newline-before-return': 2,
+    'newline-before-return': 0,
 
     // require newline after each call in a method chain
     'newline-per-chained-call': [2, {'ignoreChainWithDepth': 2}],


### PR DESCRIPTION
This patch relaxes enforcement of newlines within functions, allowing the following code to be valid:

```
function(foo) {
  const bar = 2;
  return foo + bar;
}
```

While these rules certainly help massive functions, they can hurt simplified functions and enforce some awkward syntax patterns in certain areas.