### PR TITLE
Relax arrow-body-style rules

### DIFF
--- a/rules/ecma-script6.js
+++ b/rules/ecma-script6.js
@@ -10,7 +10,7 @@ module.exports = {
   },
   'rules': {
     // only use braces where necessary
-    'arrow-body-style': [2, 'as-needed'],
+    'arrow-body-style': [0],
 
     // require parens in arrow function arguments
     'arrow-parens': [2, 'as-needed'],


### PR DESCRIPTION
This rule enforces no-braces even when an arrow function body is complex and spans multiple lines. This can create an extremely confusing syntax that makes it difficult to see indentation.

This rule change would allow the following to be valid:
```
foo(() => {
  return bar({
    foo: 1,
    bar: 2
  });
});
```