### PR TITLE
Update complexity rule

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -15,7 +15,7 @@ module.exports = {
     'class-methods-use-this': 0,
 
     // specify the maximum cyclomatic complexity allowed in code base
-    'complexity': [2, 10],
+    'complexity': [2, 20],
 
     // requires functions to have a consistent return
     'consistent-return': 1,


### PR DESCRIPTION
The new es-lint release has caused lint breakages in some of the repos (mm-course-series, etc.)